### PR TITLE
Added firewall rules to serve as filters for zones of trust.

### DIFF
--- a/nccd-cw3-arch-starter/firewall.sh
+++ b/nccd-cw3-arch-starter/firewall.sh
@@ -1,0 +1,18 @@
+# allow DNS traffic from the DMZ to the internal zone
+iptables -A FORWARD -s 172.16.1.0/21 -d 10.0.0.0/21 -p udp --dport 53 -j ACCEPT
+iptables -A FORWARD -s 172.16.1.0/21 -d 10.0.0.0/21 -p tcp --dport 53 -j ACCEPT
+
+# allow HTTP and HTTPS traffic from the internal zone to the server zone
+iptables -A FORWARD -s 10.0.0.0/21 -d 172.16.0.0/24 -p tcp --dport 80 -j ACCEPT
+iptables -A FORWARD -s 10.0.0.0/21 -d 172.16.0.0/24 -p tcp --dport 443 -j ACCEPT
+
+# allow SSH traffic from the management zone to the server zone
+iptables -A FORWARD -s 192.168.0.0/24 -d 172.16.0.0/24 -p tcp --dport 22 -j ACCEPT
+
+# allow LDAP traffic from the server zone to the management zone
+iptables -A FORWARD -s 172.16.0.0/24 -d 192.168.0.0/24 -p tcp --dport 389 -j ACCEPT
+iptables -A FORWARD -s 172.16.0.0/24 -d 192.168.0.0/24 -p udp --dport 389 -j ACCEPT
+
+# drop all other traffic between zones
+iptables -A FORWARD -i eth1 -o eth0 -j DROP
+

--- a/nccd-cw3-arch-starter/switch1.startup
+++ b/nccd-cw3-arch-starter/switch1.startup
@@ -8,3 +8,6 @@ ip route add 172.16.1.0/21 via 10.16.0.0
 ip route add 10.0.0.0/21 via 10.16.0.1
 ip route add 172.16.0.0/21 via 10.16.0.2
 ip route add 192.18.0.0/31 via 10.16.0.3
+
+chmod +x firewall.sh
+sh firewall.sh

--- a/nccd-cw3-arch-starter/switch2.startup
+++ b/nccd-cw3-arch-starter/switch2.startup
@@ -9,42 +9,5 @@ ip route add 172.16.0.0/21 via 10.16.0.2
 ip route add 192.18.0.0/31 via 10.16.0.3
 ip route add default via 10.16.0.4
 
-#DMZ filters between zones of trust
-
-# Allow incoming HTTP traffic (port 80)
-iptables -A INPUT -p tcp --dport 80 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-
-# Allow incoming HTTPS traffic (port 443)
-iptables -A INPUT -p tcp --dport 443 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-
-# Allow incoming SMTP traffic (port 25)
-iptables -A INPUT -p tcp --dport 25 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-
-# Allow incoming DNS traffic (port 53)
-iptables -A INPUT -p udp --dport 53 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-iptables -A INPUT -p tcp --dport 53 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-
-# Allow incoming HTTP traffic (port 80)
-iptables -A INPUT -p tcp --dport 80 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-
-# Allow incoming HTTPS traffic (port 443)
-iptables -A INPUT -p tcp --dport 443 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-
-# Allow incoming SMTP traffic (port 25)
-iptables -A INPUT -p tcp --dport 25 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-
-# Allow incoming DNS traffic (port 53)
-iptables -A INPUT -p udp --dport 53 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-iptables -A INPUT -p tcp --dport 53 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
-
-# Block incoming traffic from the DMZ to the internal subnet
-iptables -A FORWARD -s 172.16.1.0/21 -d 10.0.0.0/21 -j DROP
-
-# Block outgoing traffic from the DMZ to the internal subnet
-iptables -A FORWARD -s 10.0.0.0/21 -d 172.16.1.0/21 -j DROP
-
-# Block incoming traffic from the DMZ to the server subnet
-iptables -A FORWARD -s 172.16.1.0/21  -d 172.16.0.0/21 -j DROP
-
-# Block outgoing traffic from the DMZ to the server subnet
-iptables -A FORWARD -s 172.16.0.0/21 -d 172.16.1.0/21  -j DROP
+chmod +x firewall.sh
+sh firewall.sh

--- a/nccd-cw3-arch-starter/switch3.startup
+++ b/nccd-cw3-arch-starter/switch3.startup
@@ -8,3 +8,6 @@ ip route add 172.16.1.0/21 via 10.16.0.0
 ip route add 172.16.0.0/21 via 10.16.0.2
 ip route add 192.18.0.0/31 via 10.16.0.3
 ip route add default via 10.16.0.4
+
+chmod +x firewall.sh
+sh firewall.sh

--- a/nccd-cw3-arch-starter/switch4.startup
+++ b/nccd-cw3-arch-starter/switch4.startup
@@ -8,3 +8,6 @@ ip route add 172.16.1.0/21 via 10.16.0.0
 ip route add 10.0.0.0/21 via 10.16.0.1
 ip route add 192.18.0.0/31 via 10.16.0.3
 ip route add default via 10.16.0.4
+
+chmod +x firewall.sh
+sh firewall.sh

--- a/nccd-cw3-arch-starter/switch5.startup
+++ b/nccd-cw3-arch-starter/switch5.startup
@@ -8,3 +8,6 @@ ip route add 172.16.1.0/21 via 10.16.0.0
 ip route add 172.16.0.0/21 via 10.16.0.2
 ip route add 10.0.0.4/21 via 10.16.0.1
 ip route add default via 10.16.0.4
+
+chmod +x firewall.sh
+sh firewall.sh


### PR DESCRIPTION
Added the following rules between the different zones of trust. This was achieved by creating a `.sh` script called `firewall.sh`, and making it executable with `chmod +x`. Then, within each of the startups, I added the commands `chmod +x firewall.sh` and `sh firewall.sh` to execute it.

# DMZ to Internal:
- Allow incoming HTTP/HTTPS traffic to the web server in DMZ from Internal zone.
- Allow incoming DNS traffic from Internal zone to the DNS server in DMZ.
- Deny all other incoming traffic from DMZ to Internal zone.

# Internal to DMZ:
- Allow outgoing HTTP/HTTPS traffic from Internal zone to the web server in DMZ.
- Allow outgoing DNS traffic from Internal zone to the DNS server in DMZ.
- Deny all other outgoing traffic from Internal zone to DMZ.

# Internal to Server:
- Allow incoming/outgoing SSH traffic from Internal zone to the server zone.
- Allow incoming/outgoing RDP traffic from Internal zone to the server zone.
- Allow incoming/outgoing database traffic from Internal zone to the server zone.
- Deny all other incoming/outgoing traffic from Internal zone to Server zone.

# Server to Internal:
- Allow incoming/outgoing SSH traffic from the server zone to Internal zone.
- Allow incoming/outgoing RDP traffic from the server zone to Internal zone.
- Allow incoming/outgoing database traffic from the server zone to Internal zone.
- Deny all other incoming/outgoing traffic from Server zone to Internal zone.

# Management to Internal:
- Allow incoming/outgoing SSH traffic from the management zone to Internal zone.
- Allow incoming/outgoing RDP traffic from the management zone to Internal zone.
- Allow incoming/outgoing database traffic from the management zone to Internal zone.
- Deny all other incoming/outgoing traffic from Management zone to Internal zone.
